### PR TITLE
Fix README.md settings hostName -> host

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Example `settings.json`:
 ```
 {
 	"title": "Example Forum",
-	"hostName": "forum.example.org",
+	"host": "forum.example.org",
 	"nntpPort": 119,
 	"webPort": 8009,
 	"adminPort": 9009,


### PR DESCRIPTION
The key in settings.json that changes the `hostName` is called `host`.